### PR TITLE
Gitignore works similarly this way too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-**/.terraform*
+.terraform*
 *.tfstate*
-**/build
-tests/__pycache__
-tests/.pytest*
-tests/*.log
-tests/*.txt
+build
+__pycache__
+/tests/.pytest*
+/tests/*.log
+/tests/*.txt


### PR DESCRIPTION
In the [`.gitignore` documentation][1], patterns apply recursively into subdirectories when the pattern does not start with a leading slash.  See the following documentation quote (emphasis mine).

> If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. **Otherwise the pattern may also match at any level below the .gitignore level**.

So the pattern `__pycache__`, will apply to `__pycache__`, `tests/__pycache__`, `foo/bar/__pycache__` or any other arbitrary subdirectory relative to the gitignore file.

For the log files and text files in the test directory, I'm not sure if you want to exclude all log files or just the ones in the tests directory.  So I used the leading slash to indicate the just the tests directory.  The pattern before would still include subdirectories like `foo/bar/tests/*.log` since a pattern without a leading slash is recursive.

Just thought I would share what I know about gitignore files since I saw that was the last file you edited here.

Also, here's a cute kitten.

![A picture of a cute kitten](https://upload.wikimedia.org/wikipedia/commons/b/bc/Juvenile_Ragdoll.jpg)

[1]: https://git-scm.com/docs/gitignore